### PR TITLE
Add docker file for installation

### DIFF
--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -1,0 +1,24 @@
+FROM tschaffter/rstudio
+
+# install library
+RUN apt-get update -y && apt-get install libgmp3-dev -y
+
+# install conda environment
+RUN conda update conda -y && \
+    conda create -n mrtool-0.0.1 python=3.8 -y
+
+SHELL ["conda", "run", "-n", "mrtool-0.0.1", "/bin/bash", "-c"]
+
+# install all python dependencies
+RUN pip install dill numpy scipy matplotlib pandas xarray && \
+    conda install -c conda-forge cyipopt -y && \
+    pip install pycddlib xspline && \
+    pip install git+https://github.com/zhengp0/limetr.git@master && \
+    pip install git+https://github.com/ihmeuw-msca/mrtool.git@v0.0.1
+
+SHELL ["/bin/bash", "-c"]
+
+# install R dependencies
+RUN R -e "update.packages(ask = FALSE)" && \
+    R -e "install.packages('remotes')" && \
+    R -e "library(remotes); Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS='true'); install_github('ihmeuw-msca/mrtoolr')"


### PR DESCRIPTION
Here is the working Dockerfile
* use `tschaffter/rstudio` which contains `conda` and `rstudio`, same interface as `rocker/rstudtio`
* create conda environment `mrtool-0.0.1` and install all the python dependencies
* install R dependencies
To compile the docker image do
```
cd install
docker build -t mrtool:0.0.1
```